### PR TITLE
Correct typo in finduser IvaoController

### DIFF
--- a/laravel-pure/app/Http/Controllers/IvaoController.php
+++ b/laravel-pure/app/Http/Controllers/IvaoController.php
@@ -181,7 +181,7 @@ class IvaoController extends Controller
             return $staff;
         }
 
-        $finduser = User::where("id", intval($user["id"]))->first();
+        $finduser = User::where("vid", intval($user["id"]))->first();
 
         if ($finduser) {
             $finduser->firstname = $user["firstName"];


### PR DESCRIPTION
This change modifies the query to fetch the user based on the "vid" column rather than the "id" column, since the user's ID is stored in the "vid" column during user creation (line 202).

Thanks!